### PR TITLE
Add methods getDefinition, getBalances and getProfileUnits

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -164,6 +164,21 @@ declare namespace Byteball {
         callback?: (err: null | string, result: PickDivisibleCoinsForAmountResponse | null) => void,
       ): Promise<PickDivisibleCoinsForAmountResponse>;
 
+      getDefinition(
+        address: string,
+        callback?: (err: null | string, result: string | null) => void,
+      ): Promise<string[]>;
+
+      getBalances(
+        addresses: string[],
+        callback?: (err: null | string, result: string | null) => void,
+      ): Promise<string[]>;
+
+      getProfileUnits(
+        addresses: string[],
+        callback?: (err: null | string, result: string | null) => void,
+      ): Promise<string[]>;
+
       getBots(callback?: (err: null | string, result: Bot[] | null) => void): Promise<Bot[]>;
 
       getAssetMetadata(

--- a/index.d.ts
+++ b/index.d.ts
@@ -63,6 +63,18 @@ declare namespace Byteball {
     description: string;
   }
 
+  interface EncryptedPackage {
+    encrypted_message: string;
+    iv: string;
+    authtag: string;
+    dh: Dh;
+  }
+
+  interface Dh {
+    sender_ephemeral_pubkey: string;
+    recipient_ephemeral_pubkey?: string;
+  }
+
   interface JointResponse {
     joint: Joint;
   }
@@ -180,6 +192,21 @@ declare namespace Byteball {
       ): Promise<string[]>;
 
       getBots(callback?: (err: null | string, result: Bot[] | null) => void): Promise<Bot[]>;
+
+      getTempPubkey(
+        permanentPubkey: string,
+        callback?: (err: null | string, result: string | null) => void,
+      ): Promise<string[]>;
+
+      deliver(
+        params: {
+          encrypted_package: EncryptedPackage;
+          to: string;
+          pubkey: string;
+          signature: string;
+        },
+        callback?: (err: null | string, result: string | null) => void,
+      ): Promise<string[]>;
 
       getAssetMetadata(
         asset: string,

--- a/index.d.ts
+++ b/index.d.ts
@@ -63,6 +63,12 @@ declare namespace Byteball {
     description: string;
   }
 
+  interface TempPubkey {
+    temp_pubkey: string;
+    pubkey: string;
+    signature: string;
+  }
+
   interface EncryptedPackage {
     encrypted_message: string;
     iv: string;
@@ -178,25 +184,25 @@ declare namespace Byteball {
 
       getDefinition(
         address: string,
-        callback?: (err: null | string, result: string | null) => void,
-      ): Promise<string[]>;
+        callback?: (err: null | string, result: any[] | null) => void,
+      ): Promise<any[]>;
 
       getBalances(
         addresses: string[],
-        callback?: (err: null | string, result: string | null) => void,
-      ): Promise<string[]>;
+        callback?: (err: null | string, result: object) => void,
+      ): Promise<object>;
 
       getProfileUnits(
         addresses: string[],
-        callback?: (err: null | string, result: string | null) => void,
+        callback?: (err: null | string, result: string[] | any[]) => void,
       ): Promise<string[]>;
 
       getBots(callback?: (err: null | string, result: Bot[] | null) => void): Promise<Bot[]>;
 
       getTempPubkey(
         permanentPubkey: string,
-        callback?: (err: null | string, result: string | null) => void,
-      ): Promise<string[]>;
+        callback?: (err: null | string, result: TempPubkey | null) => void,
+      ): Promise<TempPubkey>;
 
       deliver(
         params: {
@@ -206,7 +212,7 @@ declare namespace Byteball {
           signature: string;
         },
         callback?: (err: null | string, result: string | null) => void,
-      ): Promise<string[]>;
+      ): Promise<string>;
 
       getAssetMetadata(
         asset: string,

--- a/src/api.json
+++ b/src/api.json
@@ -72,6 +72,17 @@
     "params": "array"
   },
   "hub/get_bots": {},
+  "hub/get_temp_pubkey": {
+    "params": "string"
+  },
+  "hub/deliver": {
+    "params": {
+      "encrypted_package": "object",
+      "to": "string",
+      "pubkey": "string",
+      "signature": "string"
+    }
+  },
   "hub/get_asset_metadata": {
     "params": "string"
   }

--- a/src/api.json
+++ b/src/api.json
@@ -62,6 +62,15 @@
       "spend_unconfirmed": "string"
     }
   },
+  "light/get_definition": {
+    "params": "string"
+  },
+  "light/get_balances": {
+    "params": "array"
+  },
+  "light/get_profile_units": {
+    "params": "array"
+  },
   "hub/get_bots": {},
   "hub/get_asset_metadata": {
     "params": "string"


### PR DESCRIPTION
Here is how to test these methods:
```
const addresses = ['TMWNLXR42CKIP4A774BQGNVBZAPHY7GH', 'ULQA63NGEZACP4N7ZMBUBISH6ZTCUS2Q'];

client.api.getDefinition(addresses[0]).then(result => { console.log('Definition', result); });
client.api.getBalances(addresses).then(result => { console.log('Balances', result); });
client.api.getProfileUnits(addresses).then(result => { console.log('Profile units', result); });
```