### PR TITLE
Check if definition exist with getDefinition

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -1,7 +1,6 @@
 import wifLib from 'wif';
 import {
   repeatString,
-  requiresDefinition,
   createPaymentMessage,
   sortOutputs,
   mapAPI,
@@ -46,9 +45,9 @@ export default class Client {
 
         const witnesses = await self.getCachedWitnesses();
 
-        const [lightProps, history] = await Promise.all([
+        const [lightProps, currentDefinition] = await Promise.all([
           self.api.getParentsAndLastBallAndWitnessListUnit({ witnesses }),
-          self.api.getHistory({ witnesses, addresses: [address] }),
+          self.api.getDefinition(address),
         ]);
 
         const bytePayment = await createPaymentMessage(
@@ -78,8 +77,6 @@ export default class Client {
           });
         }
 
-        const requireDefinition = requiresDefinition(address, history);
-
         const unit = {
           version: self.testnet ? VERSION_TESTNET : VERSION,
           alt: self.testnet ? ALT_TESTNET : ALT,
@@ -92,7 +89,7 @@ export default class Client {
         };
 
         const author = { address, authentifiers: {} };
-        if (requireDefinition) {
+        if (!currentDefinition) {
           author.definition = definition;
         }
 

--- a/src/internal.js
+++ b/src/internal.js
@@ -20,21 +20,6 @@ export const camelCase = input =>
 export const repeatString = (str, times) =>
   str.repeat ? str.repeat(times) : new Array(times + 1).join(str);
 
-export function requiresDefinition(address, history) {
-  let requireDefinition = true;
-
-  const joints = history.joints.concat(history.unstable_mc_joints);
-  joints.forEach(joint => {
-    joint.unit.authors.forEach(author => {
-      if (author.address === address && author.definition) {
-        requireDefinition = false;
-      }
-    });
-  });
-
-  return requireDefinition;
-}
-
 export async function createPaymentMessage(client, asset, outputs, address) {
   const amount = outputs.reduce((a, b) => a + b.amount, 0);
 


### PR DESCRIPTION
Instead of getHistory which is more slow. 

I tested to broadcast these units:
1: Account with definition: https://api.byteball.co/joint/t7ImrSODVRCD4lON/dGw7muENorPcZ9Gmnm95XRhRQ0= 
2: Account without definition: https://api.byteball.co/joint/uRIputuoK4Wma2LYy+SktqOLhpp4FQ+YrVo+ZyZUwkw=