### PR TITLE
Add options

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,11 @@ const byteball = require('byteball');
 const client = new byteball.Client();
 
 // Connect to a custom node
-const client = new byteball.Client('wss://byteball.fr/bb');
+const client = new byteball.Client('wss://byteball.org/bb');
 
 // Connect to testnet
-const client = new byteball.Client('wss://byteball.org/bb-test', true);
+const options = { testnet: true };
+const client = new byteball.Client('wss://byteball.org/bb-test', options);
 ```
 
 Close the client:
@@ -72,7 +73,7 @@ To compose and post unit you need first to create a Byteball wallet and fund it 
 
 [Generate a random address](https://byteballjs.com/utils/generate-wallet)
 
-Post a payment unit:
+Sending a payment:
 ```js
 const wif = '5JBFvTeSY5...'; // WIF string generated (private key)
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Ways to initiate WebSocket client:
 ```js
 const byteball = require('byteball');
 
-// Connect to mainnet official node 'wss://byteball.org/ws'
+// Connect to mainnet official node 'wss://byteball.org/bb'
 const client = new byteball.Client();
 
 // Connect to a custom node

--- a/index.d.ts
+++ b/index.d.ts
@@ -106,7 +106,7 @@ declare namespace Byteball {
   }
 
   class Client {
-    constructor(nodeAddress?: string, testnet?: boolean);
+    constructor(nodeAddress?: string, clientOptions?: any);
 
     /**
      * Broadcast a unit.
@@ -226,7 +226,7 @@ declare namespace Byteball {
     };
 
     compose: {
-      message(app, payload, auth): Promise<object>;
+      message(app, payload, options): Promise<object>;
       addressDefinitionChange(params: any): Promise<object>;
       attestation(params: any): Promise<object>;
       asset(params: any): Promise<object>;
@@ -242,7 +242,7 @@ declare namespace Byteball {
     };
 
     post: {
-      message(app, payload, auth): Promise<string>;
+      message(app, payload, options): Promise<string>;
       addressDefinitionChange(params: any): Promise<object>;
       attestation(params: any): Promise<string>;
       asset(params: any): Promise<object>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,6 +2,14 @@ export = Byteball;
 export as namespace Byteball;
 
 declare namespace Byteball {
+  interface Options {
+    testnet?: boolean;
+    wif?: string;
+    address?: string;
+    definition?: any[];
+    path?: string;
+  }
+
   interface Author {
     address: string;
     authentifiers: object;
@@ -106,7 +114,7 @@ declare namespace Byteball {
   }
 
   class Client {
-    constructor(nodeAddress?: string, clientOptions?: any);
+    constructor(nodeAddress?: string, clientOptions?: Options);
 
     /**
      * Broadcast a unit.
@@ -226,7 +234,7 @@ declare namespace Byteball {
     };
 
     compose: {
-      message(app, payload, options): Promise<object>;
+      message(app, payload, options?: Options): Promise<object>;
       addressDefinitionChange(params: any): Promise<object>;
       attestation(params: any): Promise<object>;
       asset(params: any): Promise<object>;
@@ -242,7 +250,7 @@ declare namespace Byteball {
     };
 
     post: {
-      message(app, payload, options): Promise<string>;
+      message(app, payload, options?: Options): Promise<string>;
       addressDefinitionChange(params: any): Promise<object>;
       attestation(params: any): Promise<string>;
       asset(params: any): Promise<object>;

--- a/src/client.js
+++ b/src/client.js
@@ -38,7 +38,8 @@ export default class Client {
 
     this.compose = {
       async message(app, payload, options = {}) {
-        const conf = typeof options === 'object' ? { ...this.options, options } : { wif: options };
+        const conf =
+          typeof options === 'object' ? { ...self.options, ...options } : { wif: options };
         const privKeyBuf = wifLib.decode(conf.wif, conf.testnet ? 239 : 128).privateKey;
         const pubkey = toPublicKey(privKeyBuf);
         const definition = conf.definition || ['sig', { pubkey }];

--- a/src/client.js
+++ b/src/client.js
@@ -39,7 +39,9 @@ export default class Client {
     this.compose = {
       async message(app, payload, options = {}) {
         const conf =
-          typeof options === 'object' ? { ...self.options, ...options } : { wif: options };
+          typeof options === 'object'
+            ? { ...self.options, ...options }
+            : { ...self.options, ...{ wif: options } };
         const privKeyBuf = wifLib.decode(conf.wif, conf.testnet ? 239 : 128).privateKey;
         const pubkey = toPublicKey(privKeyBuf);
         const definition = conf.definition || ['sig', { pubkey }];

--- a/src/client.js
+++ b/src/client.js
@@ -19,10 +19,10 @@ import api from './api.json';
 import apps from './apps.json';
 
 export default class Client {
-  constructor(nodeAddress = DEFAULT_NODE, testnet = false) {
+  constructor(nodeAddress = DEFAULT_NODE, clientOptions = {}) {
     const self = this;
 
-    this.testnet = testnet;
+    this.options = typeof clientOptions === 'object' ? clientOptions : { testnet: clientOptions };
     this.client = new WSClient(nodeAddress);
     this.cachedWitnesses = null;
 
@@ -37,11 +37,13 @@ export default class Client {
     this.api = {};
 
     this.compose = {
-      async message(app, payload, wif) {
-        const privKeyBuf = wifLib.decode(wif, self.testnet ? 239 : 128).privateKey;
+      async message(app, payload, options = {}) {
+        const conf = typeof options === 'object' ? { ...this.options, options } : { wif: options };
+        const privKeyBuf = wifLib.decode(conf.wif, conf.testnet ? 239 : 128).privateKey;
         const pubkey = toPublicKey(privKeyBuf);
-        const definition = ['sig', { pubkey }];
-        const address = getChash160(definition);
+        const definition = conf.definition || ['sig', { pubkey }];
+        const address = conf.address || getChash160(definition);
+        const path = conf.path || 'r';
 
         const witnesses = await self.getCachedWitnesses();
 
@@ -78,8 +80,8 @@ export default class Client {
         }
 
         const unit = {
-          version: self.testnet ? VERSION_TESTNET : VERSION,
-          alt: self.testnet ? ALT_TESTNET : ALT,
+          version: conf.testnet ? VERSION_TESTNET : VERSION,
+          alt: conf.testnet ? ALT_TESTNET : ALT,
           messages: [...customMessages],
           authors: [],
           parent_units: lightProps.parent_units,
@@ -121,8 +123,8 @@ export default class Client {
         unit.payload_commission = payloadCommission;
 
         const textToSign = getUnitHashToSign(unit);
-        const signature = sign(textToSign, privKeyBuf);
-        unit.authors[0].authentifiers = { r: signature };
+        unit.authors[0].authentifiers = {};
+        unit.authors[0].authentifiers[path] = sign(textToSign, privKeyBuf);
 
         unit.messages = [...customMessages];
         unit.unit = getUnitHash(unit);
@@ -132,8 +134,8 @@ export default class Client {
     };
 
     this.post = {
-      async message(app, payload, wif) {
-        const unit = await self.compose.message(app, payload, wif);
+      async message(app, payload, options) {
+        const unit = await self.compose.message(app, payload, options);
         return self.broadcast(unit);
       },
     };

--- a/src/client.js
+++ b/src/client.js
@@ -41,7 +41,7 @@ export default class Client {
         const conf =
           typeof options === 'object'
             ? { ...self.options, ...options }
-            : { ...self.options, ...{ wif: options } };
+            : { ...self.options, wif: options };
         const privKeyBuf = wifLib.decode(conf.wif, conf.testnet ? 239 : 128).privateKey;
         const pubkey = toPublicKey(privKeyBuf);
         const definition = conf.definition || ['sig', { pubkey }];


### PR DESCRIPTION
Add options at client level and compose / post sub methods with ability to change "definition", "address" and "path" (required for withdraw from a smart contract).

There is now 3 different way to set WIF:

On method level as plain string (like usual): 
```
client.post.text('Hello world', '5JBFvTeSY5...');
```
On method level as options object: 
```
client.post.text('Hello world', { wif: '5JBFvTeSY5...' });
```
At the client level:
```
const client = new byteball.Client('wss://byteball.org/bb', { wif: '5JBFvTeSY5...' });
client.post.text('Hello world');
```